### PR TITLE
Remove invalid return on login query

### DIFF
--- a/pages/api/auth/redirect.js
+++ b/pages/api/auth/redirect.js
@@ -3,9 +3,7 @@
 const authCodeQuery = (code) => {
   const payload = {
       query: `{
-          login(code: "${code}") {
-              accessToken
-          }
+          login(code: "${code}")
       }`
   }
 


### PR DESCRIPTION
Fixes syntax error when asking for the token response in the login query call.