### PR TITLE
Tests cases for SocialCard 392

### DIFF
--- a/cypress/component/SocialCard.cy.tsx
+++ b/cypress/component/SocialCard.cy.tsx
@@ -1,0 +1,169 @@
+import * as React from 'react'
+import { composeStories } from '@storybook/testing-react'
+import * as stories from '../../storybook/stories/SocialCard.stories'
+import terminalLog from '../support/component'
+
+const { Primary, Secondary } = composeStories(stories)
+
+describe('SocialCard.tsx', function () {
+	const timestamp = 1387503354
+	const content = "This is a cypress test"
+	const likes = 31
+	const comments = 42
+	const office = "ESB 1717"
+	const role = "Prof"
+	const TA =  {
+		firstName : "testFirst",
+		lastName : "testLast",
+		role : "TA",
+		image : "https://www.creative-tim.com/learning-lab/tailwind-starter-kit/img/team-4-470x470.png",
+		title : "Chair of Department",
+		office : "ESB 2101",
+		department : "Engineering Management & Systems Engineering",
+		}
+    beforeEach(() => {
+		cy.injectAxe()
+	})
+	it('should render component', () => {
+		cy.mount(<Primary  user={TA}/>)
+		expect(cy.get('div')).to.exist
+		expect(cy.get('img')).to.exist
+		expect(cy.get('span')).to.exist
+		expect(cy.get('button')).to.exist
+		expect(cy.get('input')).to.exist
+	})
+	it('should have no accessibility violations', () => {
+		cy.mount(<Secondary />)
+		cy.checkA11y(undefined, {
+			runOnly: {
+				type: 'tag',
+				values: ['wcag2a', 'wcag2aa', "section508"],
+			}
+		}, terminalLog)
+	})
+    it('should render a profile picture with the following class and css properties', () => {
+        cy.mount(<Primary />)
+		cy.get('img').should('have.class', 'shadow-lg rounded-full max-w-full h-12 align-middle border-none')
+							.and('have.css', 'font-size', '16px')
+							.and('have.css', 'vertical-align', 'middle')
+							.and('have.css', 'max-width', '100%')
+							.and('have.css', 'height', '48px')
+							.and('have.css', 'border-radius', '9999px')
+							.and('have.css', 'border-style', 'none')
+							.and('have.css', 'box-shadow', 'rgba(0, 0, 0, 0) 0px 0px 0px 0px, rgba(0, 0, 0, 0) 0px 0px 0px 0px, rgba(0, 0, 0, 0.1) 0px 10px 15px -3px, rgba(0, 0, 0, 0.1) 0px 4px 6px -4px')
+    })
+    it('should render component role in light color with correct content', () => {
+		cy.mount(<Primary user={TA} />)
+		cy.get('div').get('span.role').should('have.class', 'text-slate-500')
+							.and('have.css', 'color', 'rgb(100, 116, 139)')
+							.and('have.text', 'TA')
+	})
+    it('should render component user-fullName in dark color with correct content', () => {
+		cy.mount(<Primary user={TA} />)
+		cy.get('div.fullname').should('have.class', 'mb-1 text-lg font-bold text-slate-700')
+							.and('have.css', 'margin-bottom', '4px')
+							.and('have.css', 'font-size', '18px')
+							.and('have.css', 'line-height', '28px')
+							.and('have.css', 'font-weight', '700')
+							.and('contain.text', 'testFirst testLast')
+	})
+	it('should render component timestamp with department name and their office', () => {
+		TA.office=office
+		cy.mount(<Secondary user={TA} timestamp={timestamp}  content={content} />)
+		cy.get('div.department').should('have.class', 'text-xs text-neutral-500')
+							.and('have.css', 'font-size','12px')
+							.and('have.css', 'line-height','16px')
+							.and('have.css', 'color','rgb(115, 115, 115)')
+							.and('contain.text', 'ESB 1717')
+		/**
+		 * from now and counting the unix Timestamp to years, 1387503354 which was Dec 19 2013, 
+		 *   9 years from now, test result will be greater than 9 years 
+		 */
+		cy.get('div.department')
+			.invoke('text')
+			.then(parseInt)
+			.should('be.a', 'number')
+			.and('be.at.least', 9)
+	})
+	it('should render component role-symbol with correct padding and color', () => {
+		TA.role = role
+		cy.mount(<Secondary user={TA}/>)
+		expect(cy.get('div.role-symbol')).to.exist
+		cy.get('div.role-symbol').should('have.descendants', 'svg')
+		cy.get('div.role-symbol svg').should('have.class', 'text-yellow-400')
+							.and('have.css', 'color', 'rgb(227, 160, 8)')
+							.and('have.attr', 'height', '38')
+							.and('have.attr', 'width', '38')
+	})
+	it('should render component content with its input text in medium-dark gray and small font', () => {
+		cy.mount(<Primary content={content}/>)
+		cy.get('div.break-words').should('have.text', 'This is a cypress test')
+							.and('have.class', 'text-sm text-neutral-600')
+							.and('have.css', 'font-size', '14px')
+							.and('have.css', 'line-height', '20px')
+							.and('have.css', 'color', 'rgb(82, 82, 82)')
+	})
+	it('should render components for both likes and comments with according properties', () => {
+		cy.mount(<Secondary likes={likes} comments={comments}/>)
+		expect(cy.get('div.likes')).to.exist
+		cy.get('div.likes').invoke('text')
+						   	.then(parseInt)
+						   	.should('be.a', 'number')
+							.should('eq',31)
+		cy.get('div.likes').should('have.class', 'flex cursor-pointer items-center transition hover:text-slate-600 text-blue-600')
+							.and('have.css', 'display', 'flex')
+							.and('have.css', 'color', 'rgb(28, 100, 242)')
+							.and('have.css', 'align-items', 'center')
+							.and('have.css', 'cursor', 'pointer')
+							.and('have.descendants', 'svg')
+		cy.get('div.likes svg').should('have.attr', 'height', '20')
+							.and('have.attr', 'width', '20')
+
+		expect(cy.get('div.comments')).to.exist
+		cy.get('div.comments').invoke('text')
+						   	.then(parseInt)
+						   	.should('be.a', 'number')
+							.should('eq',42)
+		cy.get('div.comments').should('have.class', 'flex cursor-pointer items-center transition hover:text-slate-600 text-blue-600')
+							.and('have.css', 'display', 'flex')
+							.and('have.css', 'color', 'rgb(28, 100, 242)')
+							.and('have.css', 'align-items', 'center')
+							.and('have.css', 'cursor', 'pointer')
+							.and('have.descendants', 'svg')
+		cy.get('div.comments svg').should('have.attr', 'height', '20')
+							.and('have.attr', 'width', '20')
+	})
+	it('should render components input-text and its ability to hold text', () => {
+		cy.mount(<Primary likes={likes} comments={comments}/>)
+		cy.get('input').should('have.class', 'border-transparent bg-transparent px-5 py-2 w-full')
+							.and('have.css', 'padding-top', '8px')
+							.and('have.css', 'padding-bottom', '8px')
+							.and('have.css', 'padding-left', '20px')
+							.and('have.css', 'padding-right', '20px')
+							.and('have.css', 'background-color', 'rgba(0, 0, 0, 0)')
+							.and('have.css', 'border-color', 'rgba(0, 0, 0, 0)')
+		cy.get('input').type('Something random to post').should('have.value', 'Something random to post')
+	})
+	it('should render components file-attachment and emoji-selection', () => {
+		cy.mount(<Primary likes={likes} comments={comments}/>)
+		cy.get("button[aria-label='attach-file']").should('have.class', 'flex items-center justify-center px-5')
+							.and('have.css', 'display', 'flex')
+							.and('have.css', 'padding-left', '20px')
+							.and('have.css', 'padding-right', '20px')
+							.and('have.css', 'justify-content', 'center')
+							.and('have.css', 'align-items', 'center')
+		cy.get("button[aria-label='attach-file']").should('have.descendants', 'svg')
+		cy.get("button[aria-label='attach-file'] svg").should('have.attr', 'height', 20)
+							.and('have.attr', 'width', 20)
+
+		cy.get("button[aria-label='insert-emoji']").should('have.class', 'flex items-center justify-center px-8')
+							.and('have.css', 'display', 'flex')
+							.and('have.css', 'padding-left', '32px')
+							.and('have.css', 'padding-right', '32px')
+							.and('have.css', 'justify-content', 'center')
+							.and('have.css', 'align-items', 'center')
+		cy.get("button[aria-label='insert-emoji']").should('have.descendants', 'svg')
+		cy.get("button[aria-label='insert-emoji'] svg").should('have.attr', 'height', 20)
+							.and('have.attr', 'width', 20)
+	})
+})

--- a/storybook/components/SocialCard/SocialCard.tsx
+++ b/storybook/components/SocialCard/SocialCard.tsx
@@ -9,14 +9,13 @@ import {
 	FaStar,
 } from 'react-icons/fa'
 import { MdAttachFile } from 'react-icons/md'
-
-export const SocialCard = ({
+export const SocialCard: React.FC<SocialCardProps> = ({
 	timestamp,
 	content,
 	likes,
 	comments,
 	user,
-}: SocialCardProps) => {
+}): React.ReactElement => {
 	const [isClicked, setIsClicked] = React.useState(false)
 
 	return (
@@ -68,32 +67,32 @@ export const SocialCard = ({
 						</div>
 
 						<div className="mt-4 mb-6">
-							<div className="mb-1 text-lg font-bold text-slate-700">
-								<span className="opacity-50">{user.role}</span>{' '}
+							<div className="fullname mb-1 text-lg font-bold text-slate-700">
+								<span className="text-slate-500 role">{user.role}</span>{' '}
 								- {user.firstName} {user.lastName}
 							</div>
-							<div className="text-xs text-neutral-500">
-								{moment(timestamp).fromNow()} |{' '}
+							<div className="department text-xs text-neutral-500">
+								{moment.unix(timestamp).fromNow()} |{' '}
 								{user.department} - {user.office}
 							</div>
 						</div>
 					</div>
 
-					<div className=" px-10 ">
-						{user.role === 'Prof' && (
-							<FaStar size={38} className="text-yellow-400" />
-						)}
+					<div className="role-symbol px-10 ">
+							{user.role === 'Prof' && (
+								<FaStar size={38} className="text-yellow-400" />
+							)}
 
-						{user.role === 'Advisor' && (
-							<FaGraduationCap
-								size={38}
-								className="text-yellow-400"
-							/>
-						)}
+							{user.role === 'Advisor' && (
+								<FaGraduationCap
+									size={38}
+									className="text-yellow-400"
+								/>
+							)}
 
-						{user.role === 'TA' && (
-							<FaBookmark size={38} className="text-yellow-400" />
-						)}
+							{user.role === 'TA' && (
+								<FaBookmark size={38} className="text-yellow-400" />
+							)}
 					</div>
 				</div>
 
@@ -103,11 +102,11 @@ export const SocialCard = ({
 				<div className="border-b p-2">
 					<div className="flex items-center justify-between text-slate-500 ">
 						<div className="flex space-x-4 md:space-x-8">
-							<div className="flex cursor-pointer items-center transition hover:text-slate-600 text-blue-500">
+							<div className="likes flex cursor-pointer items-center transition hover:text-slate-600 text-blue-600">
 								<AiFillLike size={20} className="mr-1" />
 								<span className="">{likes} Likes</span>
 							</div>
-							<div className="flex cursor-pointer items-center transition hover:text-slate-600 text-blue-500">
+							<div className="comments flex cursor-pointer items-center transition hover:text-slate-600 text-blue-600">
 								<FaCommentDots size={20} className="mr-1" />
 								<span className="">{comments} comments</span>
 							</div>
@@ -130,10 +129,10 @@ export const SocialCard = ({
 
 					{/* Comment icons */}
 					<div className="flex gap-2">
-						<button className="flex items-center justify-center px-5">
+						<button aria-label="attach-file" className="flex items-center justify-center px-5">
 							<MdAttachFile size={20} className="mr-1" />
 						</button>
-						<button className="flex items-center justify-center px-8">
+						<button aria-label="insert-emoji" className="flex items-center justify-center px-8">
 							<FaRegSmile size={20} className="mr-1" />
 						</button>
 					</div>

--- a/storybook/stories/SocialCard.stories.tsx
+++ b/storybook/stories/SocialCard.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { SocialCard } from '../components/SocialCard'
-import { ComponentMeta, ComponentStory } from '@storybook/react'
+import type { SocialCardProps } from '../components/SocialCard'
+import type { ComponentMeta, ComponentStory } from '@storybook/react'
 
 export default {
 	title: 'Molecules/Social Card',
@@ -10,8 +11,7 @@ export default {
 const Template: ComponentStory<typeof SocialCard> = (args) => (
 	<SocialCard {...args} />
 )
-
-export const Primary = Template.bind({})
+export const Primary: ComponentStory<typeof SocialCard> = Template.bind({})
 Primary.args = {
 	timestamp: 1664376815,
 	content:
@@ -28,7 +28,7 @@ Primary.args = {
 		department: 'Engineering Management & Systems Engineering',
 	},
 }
-export const Secondary = Template.bind({})
+export const Secondary: ComponentStory<typeof SocialCard> = Template.bind({})
 Secondary.storyName = 'Longer Content'
 Secondary.args = {
 	...Primary.args,


### PR DESCRIPTION
1. Created tests cases for SocialCard
2. Modified SocialCard component and story for better suiting of the tests
3. Codes are working fine in UI repo 392(100% passing)
Errors:
1. Only half of the tests are passing in current setting. 
For one test that performs on a 'attach-file' icon,
cy.get("button[aria-label='attach-file']") (this passes)
but his neighbor couldn't be found,
cy.get("button[aria-label='insert-emoji']") fails (not to be found), not making too much logical sense when some tests under cy.get("button[aria-label='insert-emoji']") passes.
2. Cypress tests' css inconsistencies.
3. cy.get("button[aria-label='insert-emoji']") has padding 'padding-right', '32px' but the test suggested 0px