### PR TITLE
style(community): change width classes to flex

### DIFF
--- a/components/common/community/watched_threads_sidebar/watched_threads_sidebar.tsx
+++ b/components/common/community/watched_threads_sidebar/watched_threads_sidebar.tsx
@@ -19,7 +19,7 @@ const WatchedThreadSidebar: React.FC<WatchedThreadsSidebarProps> = ({
 				overflowY: 'visible',
 			}}
 			className={`${
-				open ? 'w-80' : 'w-3'
+				open ? 'flex-none' : 'w-3'
 			} border-l border-gray-300 relative h-screen overflow-y-scroll bg-white transition-all p-3 pt-14`}
 		>
 			{open && children}

--- a/components/common/pages/layouts/layout/layout.tsx
+++ b/components/common/pages/layouts/layout/layout.tsx
@@ -131,7 +131,7 @@ export const Layout = ({ children }) => {
 						open={open}
 						icon={null}
 					/>
-					<main className="grow">
+					<main className="flex-1">
 						<GlobalLoadingContext.Provider
 							value={{ isLoading, setLoading }}
 						>

--- a/components/common/pages/sidebar/sidebar.tsx
+++ b/components/common/pages/sidebar/sidebar.tsx
@@ -17,7 +17,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
 	handle,
 }) => {
 	return (
-		<div className={`${open ? 'w-96' : 'w-1/12'} relative`}>
+		<div className={`${open ? 'flex-none' : 'w-1/12'} relative`}>
 			<aside
 				id="sidePanel"
 				style={{


### PR DESCRIPTION
The width classes 'w-80', 'w-3', 'w-96', and 'w-1/12' were changed to flex classes 'flex-none' and 'flex-1' to improve consistency with the naming conventions. This change also fixes the jittering that was present due to uncontrolled flex growing in the communities page.