### PR TITLE
refactor(communities): add search functionality to filter by topic and search query

### DIFF
--- a/pages/communities/index.tsx
+++ b/pages/communities/index.tsx
@@ -258,19 +258,27 @@ const Index = ({}) => {
 							) {
 								return v.topics?.includes(filterType.value)
 							}
-							if(filterType.label === 'topic' && searchQuery.length > 0) {
-								return v.topics?.includes(filterType.value) && (
-									v.title
+							if (
+								filterType.label === 'topic' &&
+								searchQuery.length > 0
+							) {
+								return (
+									v.topics?.includes(filterType.value) &&
+									(v.title
 										?.toLowerCase()
 										.includes(searchQuery.toLowerCase()) ||
-									v.body
-										?.toLowerCase()
-										.includes(searchQuery.toLowerCase()) ||
-									v.topics?.some((topic) =>
-										topic
-											.toLowerCase()
-											.includes(searchQuery.toLowerCase())
-									)
+										v.body
+											?.toLowerCase()
+											.includes(
+												searchQuery.toLowerCase()
+											) ||
+										v.topics?.some((topic) =>
+											topic
+												.toLowerCase()
+												.includes(
+													searchQuery.toLowerCase()
+												)
+										))
 								)
 							}
 							if (searchQuery === '') return v.title !== null

--- a/pages/communities/index.tsx
+++ b/pages/communities/index.tsx
@@ -124,7 +124,7 @@ const Index = ({}) => {
 
 	return (
 		<div className="mx-8 flex">
-			<div className="m-10 grow">
+			<div className="m-10 grow flex-1">
 				<div className="flex my-2 items-center">
 					<img
 						src={
@@ -257,6 +257,21 @@ const Index = ({}) => {
 								searchQuery === ''
 							) {
 								return v.topics?.includes(filterType.value)
+							}
+							if(filterType.label === 'topic' && searchQuery.length > 0) {
+								return v.topics?.includes(filterType.value) && (
+									v.title
+										?.toLowerCase()
+										.includes(searchQuery.toLowerCase()) ||
+									v.body
+										?.toLowerCase()
+										.includes(searchQuery.toLowerCase()) ||
+									v.topics?.some((topic) =>
+										topic
+											.toLowerCase()
+											.includes(searchQuery.toLowerCase())
+									)
+								)
 							}
 							if (searchQuery === '') return v.title !== null
 							else if (searchQuery.length > 0)


### PR DESCRIPTION
The `grow` class was replaced with `flex-1` to improve the layout of the page. The `filterBy` function was updated to include a new condition that filters by topic and search query. If the filter type is 'topic' and the search query is not empty, the function will return true if the topic matches the filter value and if the search query is found in the title, body, or any of the topics. This improves the user experience by allowing them to search for communities based on specific topics and keywords.