### PR TITLE
lesson sidebar added to the lesson view page

### DIFF
--- a/components/common/pages/sidebar/sidebar_lessons/sidebar_lessons.tsx
+++ b/components/common/pages/sidebar/sidebar_lessons/sidebar_lessons.tsx
@@ -2,11 +2,7 @@ import * as React from 'react'
 import Link from 'next/link'
 import { IoIosArrowBack, IoIosArrowForward } from 'react-icons/io'
 
-export const SidebarLessons = ({ 
-	open,
-	handle
- }): React.ReactElement => {
-
+export const SidebarLessons = ({ open, handle }): React.ReactElement => {
 	const lessons = [
 		'Operations Research',
 		'Supply Chain Management',
@@ -24,32 +20,33 @@ export const SidebarLessons = ({
 				} top-0 h-screen w-72 bg-white transition-all drop-shadow-lg p-0`}
 			>
 				<div className="ml-8 mt-10">
-					<h6 className="font-inter my-4"
-					style={{
-						fontWeight: 400,
-						fontSize: '16px',
-					}}
-					>
-						LESSONS OVERVIEW
-					</h6>
-				{lessons.map((lesson, index) => (
-					<div
-						key={index}
-						className="font-lora flex my-3"
+					<h6
+						className="font-inter my-4"
 						style={{
-							fontWeight: 700,
+							fontWeight: 400,
 							fontSize: '16px',
 						}}
 					>
-						<Link
-							href={`/lesson`}
-							role="lesson link"
-							className="font-lora text-royalblue"
+						LESSONS OVERVIEW
+					</h6>
+					{lessons.map((lesson, index) => (
+						<div
+							key={index}
+							className="font-lora flex my-3"
+							style={{
+								fontWeight: 700,
+								fontSize: '16px',
+							}}
 						>
-							{lesson}
-						</Link>
-					</div>
-				))}
+							<Link
+								href={`/lesson`}
+								role="lesson link"
+								className="font-lora text-royalblue"
+							>
+								{lesson}
+							</Link>
+						</div>
+					))}
 				</div>
 				<button
 					id="closeButton"
@@ -60,7 +57,6 @@ export const SidebarLessons = ({
 						<IoIosArrowForward color="white" />
 					) : (
 						<IoIosArrowBack color="white" />
-						
 					)}
 				</button>
 			</aside>

--- a/components/common/pages/sidebar/sidebar_lessons/sidebar_lessons.tsx
+++ b/components/common/pages/sidebar/sidebar_lessons/sidebar_lessons.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react'
 import Link from 'next/link'
+import { IoIosArrowBack, IoIosArrowForward } from 'react-icons/io'
 
-export const SidebarLessons = ({ open, handle }): React.ReactElement => {
+export const SidebarLessons = ({ 
+	open,
+	handle
+ }): React.ReactElement => {
+
 	const lessons = [
 		'Operations Research',
 		'Supply Chain Management',
@@ -11,34 +16,60 @@ export const SidebarLessons = ({ open, handle }): React.ReactElement => {
 	]
 
 	return (
-		<div className="overflow-x-hidden max-w-screen relative min-h-screen">
+		<div className="relative">
 			<aside
 				id="sidePanel"
 				className={`absolute ${
 					open ? 'right-0' : '-right-full'
-				} top-0 h-screen overflow-y-scroll w-96 bg-white transition-all drop-shadow-lg p-0`}
+				} top-0 h-screen w-72 bg-white transition-all drop-shadow-lg p-0`}
 			>
-				<div className="flex p-6 mt-6 text-xl">
-					<h2>LESSONS OVERVIEW</h2>
-				</div>
-
+				<div className="ml-8 mt-10">
+					<h6 className="font-inter my-4"
+					style={{
+						fontWeight: 400,
+						fontSize: '16px',
+					}}
+					>
+						LESSONS OVERVIEW
+					</h6>
 				{lessons.map((lesson, index) => (
 					<div
-						className="font-montserrat text-blue mx-3 blue-800 flex text-base"
 						key={index}
+						className="font-lora flex my-3"
+						style={{
+							fontWeight: 700,
+							fontSize: '16px',
+						}}
 					>
 						<Link
 							href={`/lesson`}
 							role="lesson link"
-							className="font-montserrat text-blue m-3 blue-800 flex text-base"
+							className="font-lora text-royalblue"
 						>
 							{lesson}
 						</Link>
 					</div>
 				))}
+				</div>
+				<button
+					id="closeButton"
+					className="absolute bottom-7 -left-4 p-2 rounded-md text-red border bg-royalblue"
+					onClick={() => handle(!open)}
+				>
+					{open ? (
+						<IoIosArrowForward color="white" />
+					) : (
+						<IoIosArrowBack color="white" />
+						
+					)}
+				</button>
 			</aside>
+			<div className="w-[200px] pointer-events-none"></div>
 		</div>
 	)
 }
 
-export type SidebarLessonsProps = {}
+export type SidebarLessonsProps = {
+	handle: (open: boolean) => void
+	open: boolean
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-	"name": "frontend",
-	"version": "0.1.0",
+	"name": "glance",
+	"version": "0.3.5",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "frontend",
-			"version": "0.1.0",
+			"name": "glance",
+			"version": "0.3.5",
 			"dependencies": {
 				"@dnd-kit/core": "^6.0.7",
 				"@dnd-kit/sortable": "^7.0.2",

--- a/pages/modules/[moduleId]/collections/[collectionId]/lessons/[lessonId]/index.tsx
+++ b/pages/modules/[moduleId]/collections/[collectionId]/lessons/[lessonId]/index.tsx
@@ -99,55 +99,54 @@ const ModuleSection = () => {
 	return (
 		<section className="flex">
 			<div className="SectionContent stdcontainer grow flex-col">
-			<header>
-				<h4 className="mb-6">
-					<Link href={`/modules/${_module.id}`} passHref>
-						<a
-							title={`Return to the home page of "${_module.moduleName}"`}
-						>
-							MODULE {_module.moduleNumber}
-						</a>
-					</Link>
-					&nbsp;&nbsp;<strong>//</strong>&nbsp;&nbsp;
-					{_module.moduleName}
-				</h4>
-				<h3>{lesson.name}</h3>
-			</header>
+				<header>
+					<h4 className="mb-6">
+						<Link href={`/modules/${_module.id}`} passHref>
+							<a
+								title={`Return to the home page of "${_module.moduleName}"`}
+							>
+								MODULE {_module.moduleNumber}
+							</a>
+						</Link>
+						&nbsp;&nbsp;<strong>//</strong>&nbsp;&nbsp;
+						{_module.moduleName}
+					</h4>
+					<h3>{lesson.name}</h3>
+				</header>
 
-			<div className="flex h-4/5 gap-2 my-2">
-				{/* Section content  */}
-				<ContentLoader type={contentType} data={lessonContent} />
-			</div>
-			{/* Previous and Next buttons */}
-			<div className="w-full flex justify-between items-center">
-				{previousLesson !== null && (
-					<Link
-						href={`/modules/${moduleId}/collections/${previousLesson.collectionId}/lessons/${previousLesson.lessonId}`}
-						passHref
-					>
-						<Button>Previous</Button>
-					</Link>
-				)}
-				<div className="grow"></div>
-				{nextLesson !== null && (
-					<Link
-						href={`/modules/${moduleId}/collections/${nextLesson.collectionId}/lessons/${nextLesson.lessonId}`}
-						passHref
-					>
-						<Button>Next</Button>
-					</Link>
-				)}
-			</div>
+				<div className="flex h-4/5 gap-2 my-2">
+					{/* Section content  */}
+					<ContentLoader type={contentType} data={lessonContent} />
+				</div>
+				{/* Previous and Next buttons */}
+				<div className="w-full flex justify-between items-center">
+					{previousLesson !== null && (
+						<Link
+							href={`/modules/${moduleId}/collections/${previousLesson.collectionId}/lessons/${previousLesson.lessonId}`}
+							passHref
+						>
+							<Button>Previous</Button>
+						</Link>
+					)}
+					<div className="grow"></div>
+					{nextLesson !== null && (
+						<Link
+							href={`/modules/${moduleId}/collections/${nextLesson.collectionId}/lessons/${nextLesson.lessonId}`}
+							passHref
+						>
+							<Button>Next</Button>
+						</Link>
+					)}
+				</div>
 			</div>
 			{/* Section sidebar */}
 			<aside className="SectionSidebar bg-white h-full w-1/4 sticky top-0">
-					{/* <ModuleNavigation data={data} selected={lessonId} /> */}
-					<SidebarLessons 
+				{/* <ModuleNavigation data={data} selected={lessonId} /> */}
+				<SidebarLessons
 					open={true}
 					handle={() => console.log('toggled')}
-					/>
+				/>
 			</aside>
-
 		</section>
 	)
 }

--- a/pages/modules/[moduleId]/collections/[collectionId]/lessons/[lessonId]/index.tsx
+++ b/pages/modules/[moduleId]/collections/[collectionId]/lessons/[lessonId]/index.tsx
@@ -12,6 +12,7 @@ import { getLessonByID } from '@/scripts/get_lesson_by_id'
 import { useContext } from 'react'
 import GlobalLoadingContext from '@/contexts/global_loading_context'
 import { gql } from 'graphql-request'
+import { SidebarLessons } from '@/components/common/pages/sidebar/sidebar_lessons/sidebar_lessons'
 
 const ModuleSection = () => {
 	const { setLoading } = useContext(GlobalLoadingContext)
@@ -96,7 +97,8 @@ const ModuleSection = () => {
 	}
 
 	return (
-		<section className="stdcontainer">
+		<section className="flex">
+			<div className="SectionContent stdcontainer grow flex-col">
 			<header>
 				<h4 className="mb-6">
 					<Link href={`/modules/${_module.id}`} passHref>
@@ -115,12 +117,6 @@ const ModuleSection = () => {
 			<div className="flex h-4/5 gap-2 my-2">
 				{/* Section content  */}
 				<ContentLoader type={contentType} data={lessonContent} />
-
-				{/* Section sidebar */}
-				<aside className="bg-white h-full w-1/4">
-					{/* <ModuleNavigation data={data} selected={lessonId} /> */}
-					AAA
-				</aside>
 			</div>
 			{/* Previous and Next buttons */}
 			<div className="w-full flex justify-between items-center">
@@ -142,6 +138,16 @@ const ModuleSection = () => {
 					</Link>
 				)}
 			</div>
+			</div>
+			{/* Section sidebar */}
+			<aside className="SectionSidebar bg-white h-full w-1/4 sticky top-0">
+					{/* <ModuleNavigation data={data} selected={lessonId} /> */}
+					<SidebarLessons 
+					open={true}
+					handle={() => console.log('toggled')}
+					/>
+			</aside>
+
 		</section>
 	)
 }


### PR DESCRIPTION
made changes to the sidebar  to match sidebar requirements. 
sidebar is made sticky, but couldn't able to fix the sidebar getting cut off the screen due to overflow. 

when tried to integrate, lessons are empty when run a query. 